### PR TITLE
fix: upgrade simple-git to 3.36.0 (CVE-2026-28292)

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -21,7 +21,7 @@
     "query-string": "^6.8.1",
     "rss-parser": "^3.4.3",
     "shelljs": "^0.8.5",
-    "simple-git": "^3.17.0",
+    "simple-git": "^3.36.0",
     "underscore": "^1.9.1"
   },
   "repository": {

--- a/server/pnpm-lock.yaml
+++ b/server/pnpm-lock.yaml
@@ -48,8 +48,8 @@ importers:
         specifier: ^0.8.5
         version: 0.8.5
       simple-git:
-        specifier: ^3.17.0
-        version: 3.27.0
+        specifier: ^3.36.0
+        version: 3.36.0
       underscore:
         specifier: ^1.9.1
         version: 1.13.7
@@ -92,6 +92,12 @@ packages:
   '@octokit/types@9.3.2':
     resolution: {integrity: sha512-D4iHGTdAnEEVsB8fl95m1hiz7D5YiRdQ9b/OEb3BYRVwbLsGHcRVPz+u+BgRLNk0Q0/4iZCBqDN96j2XNxfXrA==}
 
+  '@simple-git/args-pathspec@1.0.3':
+    resolution: {integrity: sha512-ngJMaHlsWDTfjyq9F3VIQ8b7NXbBLq5j9i5bJ6XLYtD6qlDXT7fdKY2KscWWUF8t18xx052Y/PUO1K1TRc9yKA==}
+
+  '@simple-git/argv-parser@1.1.1':
+    resolution: {integrity: sha512-Q9lBcfQ+VQCpQqGJFHe5yooOS5hGdLFFbJ5R+R5aDsnkPCahtn1hSkMcORX65J2Z5lxSkD0lQorMsncuBQxYUw==}
+
   ansi-styles@4.3.0:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
@@ -122,8 +128,8 @@ packages:
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
-  debug@4.3.7:
-    resolution: {integrity: sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==}
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
     engines: {node: '>=6.0'}
     peerDependencies:
       supports-color: '*'
@@ -265,8 +271,8 @@ packages:
     engines: {node: '>=4'}
     hasBin: true
 
-  simple-git@3.27.0:
-    resolution: {integrity: sha512-ivHoFS9Yi9GY49ogc6/YAi3Fl9ROnF4VyubNylgCkA+RVqLaKWnDSzXOVzya8csELIaWaYNutsEuAhZrtOjozA==}
+  simple-git@3.36.0:
+    resolution: {integrity: sha512-cGQjLjK8bxJw4QuYT7gxHw3/IouVESbhahSsHrX97MzCL1gu2u7oy38W6L2ZIGECEfIBG4BabsWDPjBxJENv9Q==}
 
   split-on-first@1.1.0:
     resolution: {integrity: sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==}
@@ -322,7 +328,7 @@ snapshots:
 
   '@kwsites/file-exists@1.1.1':
     dependencies:
-      debug: 4.3.7
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
@@ -379,6 +385,12 @@ snapshots:
     dependencies:
       '@octokit/openapi-types': 18.1.1
 
+  '@simple-git/args-pathspec@1.0.3': {}
+
+  '@simple-git/argv-parser@1.1.1':
+    dependencies:
+      '@simple-git/args-pathspec': 1.0.3
+
   ansi-styles@4.3.0:
     dependencies:
       color-convert: 2.0.1
@@ -409,7 +421,7 @@ snapshots:
 
   concat-map@0.0.1: {}
 
-  debug@4.3.7:
+  debug@4.4.3:
     dependencies:
       ms: 2.1.3
 
@@ -535,11 +547,13 @@ snapshots:
       interpret: 1.4.0
       rechoir: 0.6.2
 
-  simple-git@3.27.0:
+  simple-git@3.36.0:
     dependencies:
       '@kwsites/file-exists': 1.1.1
       '@kwsites/promise-deferred': 1.1.1
-      debug: 4.3.7
+      '@simple-git/args-pathspec': 1.0.3
+      '@simple-git/argv-parser': 1.1.1
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 


### PR DESCRIPTION
## Summary

Upgrade `simple-git` from 3.27.0 to 3.36.0 to address CVE-2026-28292.

## Security

`simple-git` versions `>=3.15.0` and `<3.32.3` are affected by a case-sensitivity bypass in `blockUnsafeOperationsPlugin`. The bypass can allow Git's `ext::` protocol to be enabled when attacker-controlled arguments reach affected Git operations, potentially resulting in arbitrary command execution. This upgrade moves past the fixed version (3.32.3) to the latest release (3.36.0), which incorporates the upstream fix.

**Impact**: `simple-git` is vulnerable to RCE when attacker-controlled Git arguments can reach affected operations (e.g. `clone`, `fetch`, `pull`, `push`). This PR removes the vulnerable dependency version. In this repository, `server/update.js` calls `git.pull()`, `git.add()`, `git.commit()`, and `git.push(['-u', 'origin', 'master'])` with fixed, hardcoded arguments — no RSS/feed-derived data flows into git command arguments. Application-specific exploitability was not independently demonstrated; this is a precautionary dependency update.

## Changes

- `server/package.json`
- `server/pnpm-lock.yaml`

No application code or intended behavior is changed. This is a dependency-only update.

## Verification

```
cd server
pnpm install --frozen-lockfile
```

Result: succeeded — lockfile is up to date, `simple-git@3.36.0` installs cleanly. This package has no `test` or `build` script (only `once`/`docs`, which perform live scraping and git operations, so they weren't run as verification).